### PR TITLE
Fix confusing test

### DIFF
--- a/test/TestStarNotary.js
+++ b/test/TestStarNotary.js
@@ -75,9 +75,8 @@ it('lets user2 buy a star and decreases its balance in ether', async() => {
 
 // Implement Task 2 Add supporting unit tests
 
-it('can add the star name and star symbol properly', async() => {
-    // 1. create a Star with different tokenId
-    //2. Call the name and symbol properties in your Smart Contract and compare with the name and symbol provided
+it('can get contract name and symbol properly', async() => {    
+    //1. Call the name and symbol properties in your Smart Contract and compare with the name and symbol provided in the constructor
 });
 
 it('lets 2 users exchange stars', async() => {


### PR DESCRIPTION
Fix confusing test (see issue #13) by requiring properties to be set in the constructor of the contract.