### PR TITLE
Fix unittest that does not pass

### DIFF
--- a/test/TestStarNotary.js
+++ b/test/TestStarNotary.js
@@ -65,12 +65,26 @@ it('lets user2 buy a star and decreases its balance in ether', async() => {
     let balance = web3.utils.toWei(".05", "ether");
     await instance.createStar('awesome star', starId, {from: user1});
     await instance.putStarUpForSale(starId, starPrice, {from: user1});
-    let balanceOfUser1BeforeTransaction = await web3.eth.getBalance(user2);
-    const balanceOfUser2BeforeTransaction = await web3.eth.getBalance(user2);
-    await instance.buyStar(starId, {from: user2, value: balance, gasPrice:0});
-    const balanceAfterUser2BuysStar = await web3.eth.getBalance(user2);
-    let value = Number(balanceOfUser2BeforeTransaction) - Number(balanceAfterUser2BuysStar);
-    assert.equal(value, starPrice);
+    const balanceOfUser2BeforeTransaction = web3.utils.toBN(await web3.eth.getBalance(user2));
+    const txInfo = await instance.buyStar(starId, {from: user2, value: balance});
+    const balanceAfterUser2BuysStar = web3.utils.toBN(await web3.eth.getBalance(user2));    
+    
+    // Important! Note that because these are big numbers (more than Number.MAX_SAFE_INTEGER), we
+    // need to use the BN operations, instead of regular operations, which cause mathematical errors.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+    // console.log("Ok  = " + (balanceOfUser2BeforeTransaction.sub(balanceAfterUser2BuysStar)).toString());
+    // console.log("Bad = " + (balanceOfUser2BeforeTransaction - balanceAfterUser2BuysStar).toString());
+
+    // calculate the gas fee
+    const tx = await web3.eth.getTransaction(txInfo.tx);
+    const gasPrice = web3.utils.toBN(tx.gasPrice);
+    const gasUsed = web3.utils.toBN(txInfo.receipt.gasUsed);
+    const txGasCost = gasPrice.mul(gasUsed);    
+
+    // make sure that [final_balance == initial_balance - star_price - gas_fee]
+    const starPriceBN = web3.utils.toBN(starPrice); // from string
+    const expectedFinalBalance = balanceOfUser2BeforeTransaction.sub(starPriceBN).sub(txGasCost);
+    assert.equal(expectedFinalBalance.toString(), balanceAfterUser2BuysStar.toString());
 });
 
 // Implement Task 2 Add supporting unit tests


### PR DESCRIPTION
- A gasPrice of 0 can't be set with the current version of the libraries
- Gas fee needs to be accounted for
- Flag the fact that the default account balances are too big for JS to properly compute the balance changes

```
  ✓ can Create a Star (49ms)
  ✓ lets user1 put up their star for sale (53ms)
  ✓ lets user1 get the funds after the sale (100ms)
  ✓ lets user2 buy a star, if it is put up for sale (113ms)
  ✓ lets user2 buy a star and decreases its balance in ether (88ms)
  ✓ can add the star name and star symbol properly
  ✓ lets 2 users exchange stars (126ms)
  ✓ lets a user transfer a star (73ms)
  ✓ lookUptokenIdToStarInfo test (41ms)

  9 passing (668ms)
  ```